### PR TITLE
Finish test for only notify verified friends

### DIFF
--- a/app/Jobs/NotifyFriendsOfRecording.php
+++ b/app/Jobs/NotifyFriendsOfRecording.php
@@ -29,7 +29,7 @@ class NotifyFriendsOfRecording extends Job implements SelfHandling
             $this->request->get("RecordingUrl")
         );
 
-        $user->friends->verified()->each(function ($friend) use ($user, $twilio, $text) {
+        $user->friends()->verified()->get()->each(function ($friend) use ($user, $twilio, $text) {
             $twilio->text($friend->number, $text);
         });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -41,6 +41,12 @@ $factory->define(App\Friend::class, function (Faker\Generator $faker) {
     ];
 });
 
+$factory->defineAs(App\Friend::class, 'verified', function (Faker\Generator $faker) use ($factory) {
+    $friend = $factory->raw(App\Friend::class);
+
+    return array_merge($friend, ['is_verified' => true]);
+});
+
 $factory->define(App\Recording::class, function (Faker\Generator $faker) {
     return [
         'from' => '+1313' . $faker->randomNumber(7),

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -14,8 +14,8 @@ class NotificationTest extends TestCase
 
     public function test_only_verified_friends_are_notified()
     {
-        $user   = factory(User::class)->create();
-        $number = factory(PhoneNumber::class,'verified')->make();
+        $user = factory(User::class)->create();
+        $number = factory(PhoneNumber::class, 'verified')->make();
         $user->phoneNumbers()->save($number);
 
         $friend = factory(Friend::class)->make();

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use App\Friend;
+use App\Jobs\NotifyFriendsOfRecording;
+use App\Phone\TwilioClient;
 use App\PhoneNumber;
 use App\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Mockery as M;
 
 class NotificationTest extends TestCase
 {
@@ -12,22 +14,20 @@ class NotificationTest extends TestCase
 
     public function test_only_verified_friends_are_notified()
     {
-        $user = factory(User::class)->create();
-        $number = factory(PhoneNumber::class)->make();
+        $user   = factory(User::class)->create();
+        $number = factory(PhoneNumber::class,'verified')->make();
         $user->phoneNumbers()->save($number);
 
         $friend = factory(Friend::class)->make();
-        $user->friends()->save($friend);
+        $friendVerified = factory(Friend::class, 'verified')->make();
+        $user->friends()->saveMany([$friend, $friendVerified]);
 
         $request = new \Illuminate\Http\Request([
-            'From' => 'abc',
-            'CallerCity' => 'def',
-            'CallerState' => 'ghi',
-            'RecordingUrl' => 'jkl',
+            'From'         => $number->number
         ]);
 
-        $twilioMock = m::mock(); // @todo
-
+        $twilioMock = M::spy(TwilioClient::class);
+        $this->app->instance(TwilioClient::class, $twilioMock);
         $command = new NotifyFriendsOfRecording($request);
 
         $command->handle(
@@ -35,6 +35,9 @@ class NotificationTest extends TestCase
             app('Illuminate\Log\Writer')
         );
 
-        // Assert stuff
+        $twilioMock->shouldHaveReceived('text')->once()->with(
+            $friendVerified->number,
+            M::any()
+        );
     }
 }


### PR DESCRIPTION
add verified friend factory
update job to use query builder

Test checks that of the 2 friends only the verified friend receives text
