### PR TITLE
Create Twilio Signature Middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -49,6 +49,7 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'admin' => \App\Http\Middleware\Admin::class,
-        'number.verified' => \App\Http\Middleware\NumberVerified::class
+        'number.verified' => \App\Http\Middleware\NumberVerified::class,
+        'twilio.signature' => \App\Http\Middleware\VerifyTwilioSignature::class,
     ];
 }

--- a/app/Http/Middleware/VerifyTwilioSignature.php
+++ b/app/Http/Middleware/VerifyTwilioSignature.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Services_Twilio_RequestValidator;
+
+class VerifyTwilioSignature
+{
+    /**
+     * Validator Instance
+     *
+     * @var \Services_Twilio_RequestValidator
+     */
+    protected $validator;
+
+    /**
+     * TwilioSignatureValidation constructor.
+     */
+    public function __construct(Services_Twilio_RequestValidator $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * Determine if the current request is signed by Twilio
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     *
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $signature = $request->header('X-Twilio-Signature');
+        $url = $request->getUri();
+        $postParameters = $request->input();
+
+        return ! $this->validator->validate($signature, $url, $postParameters)
+                        ? response('Unauthorized.', 401)
+                        : $next($request);
+    }
+
+}

--- a/app/Http/Middleware/VerifyTwilioSignature.php
+++ b/app/Http/Middleware/VerifyTwilioSignature.php
@@ -40,5 +40,4 @@ class VerifyTwilioSignature
                         ? response('Unauthorized.', 401)
                         : $next($request);
     }
-
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -32,7 +32,7 @@ Route::group(['middleware' => ['web']], function () {
     });
 
     Route::post('call', ['as' => 'hook.call', 'uses' => 'TwilioController@callHook']);
-    Route::post('after-call', ['as' => 'hook.after-call', 'uses' => 'TwilioController@afterCallHook']);
+    Route::post('after-call', ['as' => 'hook.after-call', 'uses' => 'TwilioController@afterCallHook', 'middleware' => 'twilio.signature']);
 
     Route::get('verify/own/{hash}', ['as' => 'phones.verify', 'uses' => 'VerificationController@own']);
     Route::get('verify/friend/{hash}', ['as' => 'friends.verify', 'uses' => 'VerificationController@friend']);

--- a/app/Providers/TwilioServiceProvider.php
+++ b/app/Providers/TwilioServiceProvider.php
@@ -53,7 +53,7 @@ class TwilioServiceProvider extends ServiceProvider
 
         $this->app->bind(Services_Twilio_RequestValidator::class, function ($app) {
             return new Services_Twilio_RequestValidator(
-                 $app->config['services.twilio.token']
+                $app->config['services.twilio.token']
             );
         });
     }

--- a/app/Providers/TwilioServiceProvider.php
+++ b/app/Providers/TwilioServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Lookups_Services_Twilio;
 use Services_Twilio;
 use Services_Twilio_TinyHttp;
+use Services_Twilio_RequestValidator;
 
 class TwilioServiceProvider extends ServiceProvider
 {
@@ -47,6 +48,12 @@ class TwilioServiceProvider extends ServiceProvider
             return new TwilioClient(
                 $app->config['services.twilio.fromNumber'],
                 $app->make('Services_Twilio')
+            );
+        });
+
+        $this->app->bind(Services_Twilio_RequestValidator::class, function ($app) {
+            return new Services_Twilio_RequestValidator(
+                 $app->config['services.twilio.token']
             );
         });
     }

--- a/tests/RecordingTest.php
+++ b/tests/RecordingTest.php
@@ -12,7 +12,7 @@ use Mockery as M;
 
 class RecordingTest extends TestCase
 {
-    use DatabaseMigrations;
+    use DatabaseMigrations, WithoutMiddleware;
 
     private $callPost = [
         'AccountSid' => '290t5102934j1234',

--- a/tests/TwilioSignatureTest.php
+++ b/tests/TwilioSignatureTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Friend;
+use App\PhoneNumber;
+use App\Phone\TwilioClient;
+use App\Recording;
+use App\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Mockery as M;
+
+class TwilioSignatureTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    private $afterCallPost = [
+        'AccountSid' => '14k1203k4-0jfjsoqwer',
+        'ToZip' => '',
+        'FromState' => 'FL',
+        'Called' => '+18443116837',
+        'FromCountry' => 'US',
+        'CallerCountry' => 'US',
+        'CalledZip' => '',
+        'Direction' => 'inbound',
+        'FromCity' => 'CITY',
+        'CalledCountry' => 'US',
+        'CallerState' => 'FL',
+        'CallSid' => 'pkp0fj09123409h1234',
+        'CalledState' => '',
+        'From' => '+17346825309',
+        'CallerZip' => '12345',
+        'FromZip' => '12345',
+        'CallStatus' => 'completed',
+        'ToCity' => 'Z',
+        'ToState' => '',
+        'RecordingUrl' => 'http://api.twilio.com/2010-04-01/Accounts/Longhex/Recordings/Longhex',
+        'To' => '+18443116837',
+        'Digits' => 'hangup',
+        'ToCountry' => 'US',
+        'RecordingDuration' => '6',
+        'CallerCity' => 'CITY',
+        'ApiVersion' => '2010-04-01',
+        'Caller' => '+17346825309',
+        'CalledCity' => '',
+        'RecordingSid' => 'Long hex',
+    ];
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        App::instance(
+            TwilioClient::class,
+            M::mock(TwilioClient::class)->shouldIgnoreMissing()
+        );
+    }
+
+    public function test_only_twilio_can_post_to_url()
+    {
+        $user = factory(User::class)->create();
+        $number = new PhoneNumber([
+            'number' => TwilioClient::formatNumberFromTwilio($this->afterCallPost['Caller']),
+        ]);
+        $user->phoneNumbers()->save($number);
+
+        $this->post(route('hook.after-call'), $this->afterCallPost, $this->twilioHeader());
+        $this->assertResponseStatus(200);
+    }
+
+    public function test_twili_mismatch_signature()
+    {
+        $user = factory(User::class)->create();
+        $number = new PhoneNumber([
+            'number' => TwilioClient::formatNumberFromTwilio($this->afterCallPost['Caller']),
+        ]);
+        $user->phoneNumbers()->save($number);
+
+        $this->post(route('hook.after-call'), $this->afterCallPost, [
+            'X-Twilio-Signature' => 'fakeHash'
+        ]);
+        $this->assertResponseStatus(401);
+    }
+
+    protected function twilioHeader()
+    {
+        return [
+            'X-Twilio-Signature' => app(Services_Twilio_RequestValidator::class)->computeSignature(
+                route('hook.after-call'), $this->afterCallPost
+            )
+        ];
+    }
+}


### PR DESCRIPTION
Hi Guys. Really liking this project. Keep up the good work!

I was reviewing some of the code and I noticed that anyone could craft a fake payload that matches one coming from Twilio and hit the `/after-call` endpoint. This could be a security concern.

Twilio makes it painless to check if a request is legitimate by passing along a  `X-Twilio-Signature` header specifically signed for your account. You can read more details here: https://www.twilio.com/docs/api/security

This pull request adds a `twilio.signature` middleware that checks and validates that header. I was able to verify it working on my end, but if anyone else could test it out, that'll be great.

Thanks!
